### PR TITLE
[WIP] Update to nix 0.17.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["terminal", "tui"]
 
 [dependencies]
 ndarray = "0.8"
-nix = "0.8"
+nix = "0.17"
 raw_tty = "0.1"
 smallvec = "0.3"
 termion = "1.5"

--- a/src/base/terminal.rs
+++ b/src/base/terminal.rs
@@ -84,15 +84,17 @@ impl<'a, T: Write + AsRawFd> Terminal<'a, T> {
         stop_and_cont.add(SIGTSTP);
 
         // 1. Unblock SIGTSTP and SIGCONT, so that we actually stop when we receive another SIGTSTP
-        pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&stop_and_cont), None)?;
+        pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&stop_and_cont), None)
+            .map_err(|e| e.as_errno().expect("Only expecting io errors"))?;
 
         // 2. Reissue SIGTSTP (this time to whole the process group!)...
-        killpg(getpgrp(), SIGTSTP)?;
+        killpg(getpgrp(), SIGTSTP).map_err(|e| e.as_errno().expect("Only expecting io errors"))?;
         // ... and stop!
         // Now we are waiting for a SIGCONT.
 
         // 3. Once we receive a SIGCONT we block SIGTSTP and SIGCONT again and resume.
-        pthread_sigmask(SigmaskHow::SIG_BLOCK, Some(&stop_and_cont), None)?;
+        pthread_sigmask(SigmaskHow::SIG_BLOCK, Some(&stop_and_cont), None)
+            .map_err(|e| e.as_errno().expect("Only expecting io errors"))?;
 
         self.enter_tui()
     }

--- a/src/base/terminal.rs
+++ b/src/base/terminal.rs
@@ -32,7 +32,7 @@ use std::io::{StdoutLock, Write};
 use std::os::unix::io::AsRawFd;
 use termion;
 
-use nix::sys::signal::{kill, pthread_sigmask, SigSet, SigmaskHow, SIGCONT, SIGTSTP};
+use nix::sys::signal::{killpg, pthread_sigmask, SigSet, SigmaskHow, SIGCONT, SIGTSTP};
 use nix::unistd::getpgrp;
 
 /// A type providing an interface to the underlying physical terminal.
@@ -87,7 +87,7 @@ impl<'a, T: Write + AsRawFd> Terminal<'a, T> {
         pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&stop_and_cont), None)?;
 
         // 2. Reissue SIGTSTP (this time to whole the process group!)...
-        kill(-getpgrp(), SIGTSTP)?;
+        killpg(getpgrp(), SIGTSTP)?;
         // ... and stop!
         // Now we are waiting for a SIGCONT.
 


### PR DESCRIPTION
Use killpg(pid, sig) instead of kill(-pid, sig).

---

Hi! The current nix version (`0.8`) in this library is broken for ppc targets. I would like to update to the latest version (`0.17`), but from release `0.9` onwards they removed the `From<nix::Error> for std::io::Error` trait impl: https://github.com/nix-rust/nix/pull/614

Therefore, when compiling, I get these errors:

```
    Checking unsegen v0.2.4 (/home/ericonr/mypro/ugdb/unsegen)
error[E0277]: `?` couldn't convert the error to `std::io::Error`
  --> src/base/terminal.rs:87:77
   |
87 |         pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&stop_and_cont), None)?;
   |                                                                             ^ the trait `std::convert::From<nix::Error>` is not implemented for `std::io::Error`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
   = help: the following implementations were found:
             <std::io::Error as std::convert::From<nix::errno::Errno>>
             <std::io::Error as std::convert::From<std::ffi::NulError>>
             <std::io::Error as std::convert::From<std::io::ErrorKind>>
             <std::io::Error as std::convert::From<std::io::IntoInnerError<W>>>
   = note: required by `std::convert::From::from`

error[E0277]: `?` couldn't convert the error to `std::io::Error`
  --> src/base/terminal.rs:90:35
   |
90 |         killpg(getpgrp(), SIGTSTP)?;
   |                                   ^ the trait `std::convert::From<nix::Error>` is not implemented for `std::io::Error`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
   = help: the following implementations were found:
             <std::io::Error as std::convert::From<nix::errno::Errno>>
             <std::io::Error as std::convert::From<std::ffi::NulError>>
             <std::io::Error as std::convert::From<std::io::ErrorKind>>
             <std::io::Error as std::convert::From<std::io::IntoInnerError<W>>>
   = note: required by `std::convert::From::from`

error[E0277]: `?` couldn't convert the error to `std::io::Error`
  --> src/base/terminal.rs:95:75
   |
95 |         pthread_sigmask(SigmaskHow::SIG_BLOCK, Some(&stop_and_cont), None)?;
   |                                                                           ^ the trait `std::convert::From<nix::Error>` is not implemented for `std::io::Error`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
   = help: the following implementations were found:
             <std::io::Error as std::convert::From<nix::errno::Errno>>
             <std::io::Error as std::convert::From<std::ffi::NulError>>
             <std::io::Error as std::convert::From<std::io::ErrorKind>>
             <std::io::Error as std::convert::From<std::io::IntoInnerError<W>>>
   = note: required by `std::convert::From::from`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `unsegen`.

To learn more, run the command again with --verbose.
```

How would you suggest we go about restructuring the code to allow it to work with newer nix versions?